### PR TITLE
Stop accepting whitespace in `FromHex::from_hex`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,10 +76,6 @@ impl FromHex for Vec<u8> {
                 b'A'...b'F' => buf |= byte - b'A' + 10,
                 b'a'...b'f' => buf |= byte - b'a' + 10,
                 b'0'...b'9' => buf |= byte - b'0',
-                b' '|b'\r'|b'\n'|b'\t' => {
-                    buf >>= 4;
-                    continue
-                }
                 _ => {
                     let ch = s[idx..].chars().next().unwrap();
                     return Err(FromHexError::InvalidHexCharacter {
@@ -140,5 +136,14 @@ mod test {
     #[test]
     pub fn test_empty() {
         assert_eq!(Vec::from_hex("").unwrap(), b"");
+    }
+
+    #[test]
+    pub fn test_from_hex_whitespace() {
+        assert_eq!(Vec::from_hex("666f 6f626172").unwrap_err(),
+                   FromHexError::InvalidHexCharacter {
+                       c: ' ',
+                       index: 4
+                   });
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/KokaKiwi/rust-hex/issues/4.