### PR TITLE
Add basic benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ description = "Encoding and decoding data into/from hexadecimal representation."
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/hex/"
 repository = "https://github.com/KokaKiwi/rust-hex"
+
+[features]
+benchmarks = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "benchmarks", feature(test))]
+
 // Copyright (c) 2013-2014 The Rust Project Developers.
 // Copyright (c) 2015-2017 The rust-hex Developers.
 //
@@ -381,5 +383,25 @@ mod test {
             <[u8; 5] as FromHex>::from_hex("666f6f626172"),
             Err(FromHexError::InvalidStringLength)
         );
+    }
+}
+
+
+#[cfg(all(feature = "benchmarks", test))]
+mod bench {
+    extern crate test;
+    use self::test::Bencher;
+
+    use super::*;
+
+    const MY_OWN_SOURCE: &[u8] = include_bytes!("lib.rs");
+
+    #[bench]
+    fn a_bench(b: &mut Bencher) {
+        b.bytes = MY_OWN_SOURCE.len() as u64;
+
+        b.iter(|| {
+            encode(MY_OWN_SOURCE)
+        });
     }
 }


### PR DESCRIPTION
I was curious about an alternate solution, so I created a (simple!) benchmark. The alternate wasn't useful, but maybe the benchmark will be for others:

```
$ cargo +nightly --version
cargo 0.25.0-nightly (a88fbace4 2017-12-29)
$ cargo +nightly bench --features=benchmarks
test bench::a_bench ... bench:      46,120 ns/iter (+/- 2,220) = 245 MB/s
```