### PR TITLE
Support no_std

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ Cargo.lock
 # Misc stuff
 .*
 !.gitignore
+!.travis.yml
 !.gitlab-ci.yml
 !.gitlab-ci-matrix.yml

--- a/.gitlab-ci-matrix.yml
+++ b/.gitlab-ci-matrix.yml
@@ -21,6 +21,7 @@ steps:
     stage: test
     script:
       - cargo test
+      - cargo test --no-default-features
     dependencies:
       - compile
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,6 +113,7 @@ test:rust-stable:
     - compile:rust-stable
   script:
     - cargo test
+    - cargo test --no-default-features
   variables:
     RUST_KEY: rust-stable
 
@@ -123,6 +124,7 @@ test:rust-stable-musl:
     - compile:rust-stable-musl
   script:
     - cargo test
+    - cargo test --no-default-features
   variables:
     RUST_KEY: rust-stable-musl
 
@@ -133,6 +135,7 @@ test:rust-beta:
     - compile:rust-beta
   script:
     - cargo test
+    - cargo test --no-default-features
   variables:
     RUST_KEY: rust-beta
 
@@ -143,6 +146,7 @@ test:rust-beta-musl:
     - compile:rust-beta-musl
   script:
     - cargo test
+    - cargo test --no-default-features
   variables:
     RUST_KEY: rust-beta-musl
 
@@ -153,6 +157,7 @@ test:rust-nightly:
     - compile:rust-nightly
   script:
     - cargo test
+    - cargo test --no-default-features
   variables:
     RUST_KEY: rust-nightly
   allow_failure: true
@@ -164,6 +169,7 @@ test:rust-nightly-musl:
     - compile:rust-nightly-musl
   script:
     - cargo test
+    - cargo test --no-default-features
   variables:
     RUST_KEY: rust-nightly-musl
   allow_failure: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,20 @@
 language: rust
+os:
+  - linux
+  - windows
+  - osx
 rust:
   - stable
   - beta
   - nightly
+env:
+  global:
+    - RUST_BACKTRACE=1
+    - RUSTFLAGS="-D warnings"
 matrix:
   allow_failures:
     - rust: nightly
+
+script:
+  - cargo test
+  - cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ description = "Encoding and decoding data into/from hexadecimal representation."
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/hex/"
 repository = "https://github.com/KokaKiwi/rust-hex"
+edition = "2018"
 
 [features]
+default = ["std"]
+std = []
 benchmarks = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::{vec::Vec, string::String};
+use alloc::{string::String, vec::Vec};
 
 use core::fmt;
 use core::iter;
@@ -58,8 +58,8 @@ pub trait ToHex {
     fn encode_hex_upper<T: iter::FromIterator<char>>(&self) -> T;
 }
 
-const HEX_CHARS_LOWER: &'static[u8; 16] = b"0123456789abcdef";
-const HEX_CHARS_UPPER: &'static[u8; 16] = b"0123456789ABCDEF";
+const HEX_CHARS_LOWER: &[u8; 16] = b"0123456789abcdef";
+const HEX_CHARS_UPPER: &[u8; 16] = b"0123456789ABCDEF";
 
 struct BytesToHexChars<'a> {
     inner: ::core::slice::Iter<'a, u8>,
@@ -71,7 +71,7 @@ impl<'a> BytesToHexChars<'a> {
     fn new(inner: &'a [u8], table: &'static [u8; 16]) -> BytesToHexChars<'a> {
         BytesToHexChars {
             inner: inner.iter(),
-            table: table,
+            table,
             next: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(feature = "benchmarks", feature(test))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 // Copyright (c) 2013-2014 The Rust Project Developers.
 // Copyright (c) 2015-2018 The rust-hex Developers.
@@ -25,9 +26,11 @@
 //! }
 //! ```
 
-extern crate core;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{vec::Vec, string::String};
 
-use std::error;
 use core::fmt;
 use core::iter;
 
@@ -142,7 +145,8 @@ pub enum FromHexError {
     InvalidStringLength,
 }
 
-impl error::Error for FromHexError {
+#[cfg(feature = "std")]
+impl std::error::Error for FromHexError {
     fn description(&self) -> &str {
         match *self {
             FromHexError::InvalidHexCharacter { .. } => "invalid character",
@@ -347,7 +351,7 @@ pub fn decode_to_slice<T: AsRef<[u8]>>(data: T, out: &mut [u8]) -> Result<(), Fr
 
 #[cfg(test)]
 mod test {
-    use super::{encode, decode, FromHex, FromHexError};
+    use super::*;
 
     #[test]
     fn test_encode() {
@@ -356,7 +360,7 @@ mod test {
 
     #[test]
     fn test_decode() {
-        assert_eq!(decode("666f6f626172"), Ok("foobar".to_owned().into_bytes()));
+        assert_eq!(decode("666f6f626172"), Ok(String::from("foobar").into_bytes()));
     }
 
     #[test]


### PR DESCRIPTION
# What have I changed? 

1. Migrate to 2018 edition
2. Support no_std (rustc 1.36 has stabilize `alloc` crate)
3. Modify CI config