### PR TITLE
Use criterion for benchmarking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,14 @@ matrix:
   allow_failures:
     - rust: nightly
 
+install:
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then rustup component add rustfmt; fi
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then rustup component add clippy; fi
+
 script:
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then cargo fmt -- --check; fi
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then cargo clippy -- -D clippy::all; fi
   - cargo test
   - cargo test --no-default-features
+  # Validate benches still work.
+  - cargo bench --all -- --test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,11 @@ edition = "2018"
 [features]
 default = ["std"]
 std = []
-benchmarks = []
+
+[[bench]]
+name = "hex"
+harness = false
+
+[dev-dependencies]
+criterion = "0.2"
+rustc-hex = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ harness = false
 [dev-dependencies]
 criterion = "0.2"
 rustc-hex = "2.0"
+faster-hex = "0.3"

--- a/benches/hex.rs
+++ b/benches/hex.rs
@@ -1,49 +1,68 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rustc_hex::{FromHex, ToHex};
 
-const SMALL_DATA: &[u8] =
-    b"Day before yesterday I saw a rabbit, and yesterday a deer, and today, you.";
-const BIG_DATA: &[u8] = include_bytes!("../src/lib.rs");
+const DATA: &[u8] = include_bytes!("../src/lib.rs");
 
-fn bench_small_data(c: &mut Criterion) {
-    c.bench_function("hex_encode_small", |b| {
-        b.iter(|| black_box(hex::encode(SMALL_DATA)))
+fn bench_encode(c: &mut Criterion) {
+    c.bench_function("hex_encode", |b| b.iter(|| black_box(hex::encode(DATA))));
+
+    c.bench_function("rustc_hex_encode", |b| {
+        b.iter(|| black_box(DATA.to_hex::<String>()))
     });
 
-    c.bench_function("rustc_hex_encode_small", |b| {
-        b.iter(|| black_box(SMALL_DATA.to_hex::<String>()))
+    c.bench_function("faster_hex_encode", |b| {
+        b.iter(|| black_box(faster_hex::hex_string(DATA).unwrap()))
     });
 
-    c.bench_function("hex_decode_small", |b| {
-        let hex = hex::encode(SMALL_DATA);
-        b.iter(|| black_box(hex::decode(&hex).unwrap()))
-    });
-
-    c.bench_function("rustc_hex_decode_small", |b| {
-        let hex = hex::encode(SMALL_DATA);
-        b.iter(|| black_box(hex.from_hex::<Vec<u8>>().unwrap()))
+    c.bench_function("faster_hex_encode_fallback", |b| {
+        b.iter(|| {
+            let mut buffer = vec![0; DATA.len() * 2];
+            black_box(faster_hex::hex_encode_fallback(DATA, &mut buffer));
+        })
     });
 }
 
-fn bench_big_data(c: &mut Criterion) {
-    c.bench_function("hex_encode_big", |b| {
-        b.iter(|| black_box(hex::encode(BIG_DATA)))
-    });
-
-    c.bench_function("rustc_hex_encode_big", |b| {
-        b.iter(|| black_box(BIG_DATA.to_hex::<String>()))
-    });
-
-    c.bench_function("hex_decode_big", |b| {
-        let hex = hex::encode(BIG_DATA);
+fn bench_decode(c: &mut Criterion) {
+    c.bench_function("hex_decode", |b| {
+        let hex = hex::encode(DATA);
         b.iter(|| black_box(hex::decode(&hex).unwrap()))
     });
 
-    c.bench_function("rustc_hex_decode_big", |b| {
-        let hex = hex::encode(BIG_DATA);
+    c.bench_function("rustc_hex_decode", |b| {
+        let hex = DATA.to_hex::<String>();
         b.iter(|| black_box(hex.from_hex::<Vec<u8>>().unwrap()))
+    });
+
+    c.bench_function("faster_hex_decode", move |b| {
+        let hex = faster_hex::hex_string(DATA).unwrap();
+        let len = DATA.len();
+        b.iter(|| {
+            let mut dst = Vec::with_capacity(len);
+            dst.resize(len, 0);
+            black_box(faster_hex::hex_decode(hex.as_bytes(), &mut dst).unwrap());
+        })
+    });
+
+    c.bench_function("faster_hex_decode_unchecked", |b| {
+        let hex = faster_hex::hex_string(DATA).unwrap();
+        let len = DATA.len();
+        b.iter(|| {
+            let mut dst = Vec::with_capacity(len);
+            dst.resize(len, 0);
+            black_box(faster_hex::hex_decode_unchecked(hex.as_bytes(), &mut dst));
+        })
+    });
+
+    c.bench_function("faster_hex_decode_fallback", |b| {
+        let hex = faster_hex::hex_string(DATA).unwrap();
+        let len = DATA.len();
+        b.iter(|| {
+            let mut dst = Vec::with_capacity(len);
+            dst.resize(len, 0);
+            black_box(faster_hex::hex_decode_fallback(hex.as_bytes(), &mut dst));
+        })
     });
 }
 
-criterion_group!(benches, bench_small_data, bench_big_data);
+criterion_group!(benches, bench_encode, bench_decode);
 criterion_main!(benches);

--- a/benches/hex.rs
+++ b/benches/hex.rs
@@ -1,0 +1,49 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rustc_hex::{FromHex, ToHex};
+
+const SMALL_DATA: &[u8] =
+    b"Day before yesterday I saw a rabbit, and yesterday a deer, and today, you.";
+const BIG_DATA: &[u8] = include_bytes!("../src/lib.rs");
+
+fn bench_small_data(c: &mut Criterion) {
+    c.bench_function("hex_encode_small", |b| {
+        b.iter(|| black_box(hex::encode(SMALL_DATA)))
+    });
+
+    c.bench_function("rustc_hex_encode_small", |b| {
+        b.iter(|| black_box(SMALL_DATA.to_hex::<String>()))
+    });
+
+    c.bench_function("hex_decode_small", |b| {
+        let hex = hex::encode(SMALL_DATA);
+        b.iter(|| black_box(hex::decode(&hex).unwrap()))
+    });
+
+    c.bench_function("rustc_hex_decode_small", |b| {
+        let hex = hex::encode(SMALL_DATA);
+        b.iter(|| black_box(hex.from_hex::<Vec<u8>>().unwrap()))
+    });
+}
+
+fn bench_big_data(c: &mut Criterion) {
+    c.bench_function("hex_encode_big", |b| {
+        b.iter(|| black_box(hex::encode(BIG_DATA)))
+    });
+
+    c.bench_function("rustc_hex_encode_big", |b| {
+        b.iter(|| black_box(BIG_DATA.to_hex::<String>()))
+    });
+
+    c.bench_function("hex_decode_big", |b| {
+        let hex = hex::encode(BIG_DATA);
+        b.iter(|| black_box(hex::decode(&hex).unwrap()))
+    });
+
+    c.bench_function("rustc_hex_decode_big", |b| {
+        let hex = hex::encode(BIG_DATA);
+        b.iter(|| black_box(hex.from_hex::<Vec<u8>>().unwrap()))
+    });
+}
+
+criterion_group!(benches, bench_small_data, bench_big_data);
+criterion_main!(benches);

--- a/benches/hex.rs
+++ b/benches/hex.rs
@@ -1,23 +1,21 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use rustc_hex::{FromHex, ToHex};
 
 const DATA: &[u8] = include_bytes!("../src/lib.rs");
 
 fn bench_encode(c: &mut Criterion) {
-    c.bench_function("hex_encode", |b| b.iter(|| black_box(hex::encode(DATA))));
+    c.bench_function("hex_encode", |b| b.iter(|| hex::encode(DATA)));
 
-    c.bench_function("rustc_hex_encode", |b| {
-        b.iter(|| black_box(DATA.to_hex::<String>()))
-    });
+    c.bench_function("rustc_hex_encode", |b| b.iter(|| DATA.to_hex::<String>()));
 
     c.bench_function("faster_hex_encode", |b| {
-        b.iter(|| black_box(faster_hex::hex_string(DATA).unwrap()))
+        b.iter(|| faster_hex::hex_string(DATA).unwrap())
     });
 
     c.bench_function("faster_hex_encode_fallback", |b| {
         b.iter(|| {
             let mut buffer = vec![0; DATA.len() * 2];
-            black_box(faster_hex::hex_encode_fallback(DATA, &mut buffer));
+            faster_hex::hex_encode_fallback(DATA, &mut buffer);
         })
     });
 }
@@ -25,12 +23,12 @@ fn bench_encode(c: &mut Criterion) {
 fn bench_decode(c: &mut Criterion) {
     c.bench_function("hex_decode", |b| {
         let hex = hex::encode(DATA);
-        b.iter(|| black_box(hex::decode(&hex).unwrap()))
+        b.iter(|| hex::decode(&hex).unwrap())
     });
 
     c.bench_function("rustc_hex_decode", |b| {
         let hex = DATA.to_hex::<String>();
-        b.iter(|| black_box(hex.from_hex::<Vec<u8>>().unwrap()))
+        b.iter(|| hex.from_hex::<Vec<u8>>().unwrap())
     });
 
     c.bench_function("faster_hex_decode", move |b| {
@@ -39,7 +37,7 @@ fn bench_decode(c: &mut Criterion) {
         b.iter(|| {
             let mut dst = Vec::with_capacity(len);
             dst.resize(len, 0);
-            black_box(faster_hex::hex_decode(hex.as_bytes(), &mut dst).unwrap());
+            faster_hex::hex_decode(hex.as_bytes(), &mut dst).unwrap();
         })
     });
 
@@ -49,7 +47,7 @@ fn bench_decode(c: &mut Criterion) {
         b.iter(|| {
             let mut dst = Vec::with_capacity(len);
             dst.resize(len, 0);
-            black_box(faster_hex::hex_decode_unchecked(hex.as_bytes(), &mut dst));
+            faster_hex::hex_decode_unchecked(hex.as_bytes(), &mut dst);
         })
     });
 
@@ -59,7 +57,7 @@ fn bench_decode(c: &mut Criterion) {
         b.iter(|| {
             let mut dst = Vec::with_capacity(len);
             dst.resize(len, 0);
-            black_box(faster_hex::hex_decode_fallback(hex.as_bytes(), &mut dst));
+            faster_hex::hex_decode_fallback(hex.as_bytes(), &mut dst);
         })
     });
 }

--- a/benches/hex.rs
+++ b/benches/hex.rs
@@ -14,8 +14,9 @@ fn bench_encode(c: &mut Criterion) {
 
     c.bench_function("faster_hex_encode_fallback", |b| {
         b.iter(|| {
-            let mut buffer = vec![0; DATA.len() * 2];
-            faster_hex::hex_encode_fallback(DATA, &mut buffer);
+            let mut dst = vec![0; DATA.len() * 2];
+            faster_hex::hex_encode_fallback(DATA, &mut dst);
+            dst
         })
     });
 }
@@ -38,6 +39,7 @@ fn bench_decode(c: &mut Criterion) {
             let mut dst = Vec::with_capacity(len);
             dst.resize(len, 0);
             faster_hex::hex_decode(hex.as_bytes(), &mut dst).unwrap();
+            dst
         })
     });
 
@@ -48,6 +50,7 @@ fn bench_decode(c: &mut Criterion) {
             let mut dst = Vec::with_capacity(len);
             dst.resize(len, 0);
             faster_hex::hex_decode_unchecked(hex.as_bytes(), &mut dst);
+            dst
         })
     });
 
@@ -58,6 +61,7 @@ fn bench_decode(c: &mut Criterion) {
             let mut dst = Vec::with_capacity(len);
             dst.resize(len, 0);
             faster_hex::hex_decode_fallback(hex.as_bytes(), &mut dst);
+            dst
         })
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![cfg_attr(feature = "benchmarks", feature(test))]
-#![cfg_attr(not(feature = "std"), no_std)]
-
 // Copyright (c) 2013-2014 The Rust Project Developers.
 // Copyright (c) 2015-2018 The rust-hex Developers.
 //
@@ -25,6 +22,9 @@
 //!     println!("{}", hex_string); // Prints '48656c6c6f20776f726c6421'
 //! }
 //! ```
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::unreadable_literal)]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
@@ -83,13 +83,11 @@ impl<'a> Iterator for BytesToHexChars<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         match self.next.take() {
             Some(current) => Some(current),
-            None => {
-                self.inner.next().map(|byte| {
-                    let current = self.table[(byte >> 4) as usize] as char;
-                    self.next = Some(self.table[(byte & 0xf) as usize] as char);
-                    current
-                })
-            }
+            None => self.inner.next().map(|byte| {
+                let current = self.table[(byte >> 4) as usize] as char;
+                self.next = Some(self.table[(byte & 0xf) as usize] as char);
+                current
+            }),
         }
     }
 
@@ -109,9 +107,7 @@ impl<'a> iter::ExactSizeIterator for BytesToHexChars<'a> {
     }
 }
 
-fn encode_to_iter<T: iter::FromIterator<char>>(table: &'static [u8; 16],
-                                               source: &[u8]) -> T
-{
+fn encode_to_iter<T: iter::FromIterator<char>>(table: &'static [u8; 16], source: &[u8]) -> T {
     BytesToHexChars::new(source, table).collect()
 }
 
@@ -130,10 +126,7 @@ impl<T: AsRef<[u8]>> ToHex for T {
 pub enum FromHexError {
     /// An invalid character was found. Valid ones are: `0...9`, `a...f`
     /// or `A...F`.
-    InvalidHexCharacter {
-        c: char,
-        index: usize,
-    },
+    InvalidHexCharacter { c: char, index: usize },
 
     /// A hex string's length needs to be even, as two digits correspond to
     /// one byte.
@@ -152,7 +145,6 @@ impl std::error::Error for FromHexError {
             FromHexError::InvalidHexCharacter { .. } => "invalid character",
             FromHexError::OddLength => "odd number of digits",
             FromHexError::InvalidStringLength => "invalid string length",
-
         }
     }
 }
@@ -160,12 +152,11 @@ impl std::error::Error for FromHexError {
 impl fmt::Display for FromHexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            FromHexError::InvalidHexCharacter { c, index } =>
-                write!(f, "Invalid character '{}' at position {}", c, index),
-            FromHexError::OddLength =>
-                write!(f, "Odd number of digits"),
-            FromHexError::InvalidStringLength =>
-                write!(f, "Invalid string length"),
+            FromHexError::InvalidHexCharacter { c, index } => {
+                write!(f, "Invalid character '{}' at position {}", c, index)
+            }
+            FromHexError::OddLength => write!(f, "Odd number of digits"),
+            FromHexError::InvalidStringLength => write!(f, "Invalid string length"),
         }
     }
 }
@@ -206,12 +197,10 @@ fn val(c: u8, idx: usize) -> Result<u8, FromHexError> {
         b'A'..=b'F' => Ok(c - b'A' + 10),
         b'a'..=b'f' => Ok(c - b'a' + 10),
         b'0'..=b'9' => Ok(c - b'0'),
-        _ => {
-            Err(FromHexError::InvalidHexCharacter {
-                c: c as char,
-                index: idx,
-            })
-        }
+        _ => Err(FromHexError::InvalidHexCharacter {
+            c: c as char,
+            index: idx,
+        }),
     }
 }
 
@@ -224,9 +213,10 @@ impl FromHex for Vec<u8> {
             return Err(FromHexError::OddLength);
         }
 
-        hex.chunks(2).enumerate().map(|(i, pair)| {
-            Ok(val(pair[0], 2 * i)? << 4 | val(pair[1], 2 * i + 1)?)
-        }).collect()
+        hex.chunks(2)
+            .enumerate()
+            .map(|(i, pair)| Ok(val(pair[0], 2 * i)? << 4 | val(pair[1], 2 * i + 1)?))
+            .collect()
     }
 }
 
@@ -342,8 +332,7 @@ pub fn decode_to_slice<T: AsRef<[u8]>>(data: T, out: &mut [u8]) -> Result<(), Fr
     }
 
     for (i, byte) in out.iter_mut().enumerate() {
-        *byte = val(data[2 * i], 2 * i)? << 4
-            | val(data[2 * i + 1], 2 * i + 1)?;
+        *byte = val(data[2 * i], 2 * i)? << 4 | val(data[2 * i + 1], 2 * i + 1)?;
     }
 
     Ok(())
@@ -360,39 +349,27 @@ mod test {
 
     #[test]
     fn test_decode() {
-        assert_eq!(decode("666f6f626172"), Ok(String::from("foobar").into_bytes()));
+        assert_eq!(
+            decode("666f6f626172"),
+            Ok(String::from("foobar").into_bytes())
+        );
     }
 
     #[test]
     pub fn test_from_hex_okay_str() {
-        assert_eq!(
-            Vec::from_hex("666f6f626172").unwrap(),
-            b"foobar"
-        );
-        assert_eq!(
-            Vec::from_hex("666F6F626172").unwrap(),
-            b"foobar"
-        );
+        assert_eq!(Vec::from_hex("666f6f626172").unwrap(), b"foobar");
+        assert_eq!(Vec::from_hex("666F6F626172").unwrap(), b"foobar");
     }
 
     #[test]
     pub fn test_from_hex_okay_bytes() {
-        assert_eq!(
-            Vec::from_hex(b"666f6f626172").unwrap(),
-            b"foobar"
-        );
-        assert_eq!(
-            Vec::from_hex(b"666F6F626172").unwrap(),
-            b"foobar"
-        );
+        assert_eq!(Vec::from_hex(b"666f6f626172").unwrap(), b"foobar");
+        assert_eq!(Vec::from_hex(b"666F6F626172").unwrap(), b"foobar");
     }
 
     #[test]
     pub fn test_invalid_length() {
-        assert_eq!(
-            Vec::from_hex("1").unwrap_err(),
-            FromHexError::OddLength
-        );
+        assert_eq!(Vec::from_hex("1").unwrap_err(), FromHexError::OddLength);
         assert_eq!(
             Vec::from_hex("666f6f6261721").unwrap_err(),
             FromHexError::OddLength
@@ -403,10 +380,7 @@ mod test {
     pub fn test_invalid_char() {
         assert_eq!(
             Vec::from_hex("66ag").unwrap_err(),
-            FromHexError::InvalidHexCharacter {
-                c: 'g',
-                index: 3
-            }
+            FromHexError::InvalidHexCharacter { c: 'g', index: 3 }
         );
     }
 
@@ -419,10 +393,7 @@ mod test {
     pub fn test_from_hex_whitespace() {
         assert_eq!(
             Vec::from_hex("666f 6f62617").unwrap_err(),
-            FromHexError::InvalidHexCharacter {
-                c: ' ',
-                index: 4
-            }
+            FromHexError::InvalidHexCharacter { c: ' ', index: 4 }
         );
     }
 
@@ -437,25 +408,5 @@ mod test {
             <[u8; 5] as FromHex>::from_hex("666f6f626172"),
             Err(FromHexError::InvalidStringLength)
         );
-    }
-}
-
-
-#[cfg(all(feature = "benchmarks", test))]
-mod bench {
-    extern crate test;
-    use self::test::Bencher;
-
-    use super::*;
-
-    const MY_OWN_SOURCE: &[u8] = include_bytes!("lib.rs");
-
-    #[bench]
-    fn a_bench(b: &mut Bencher) {
-        b.bytes = MY_OWN_SOURCE.len() as u64;
-
-        b.iter(|| {
-            encode(MY_OWN_SOURCE)
-        });
     }
 }


### PR DESCRIPTION
# What have I changed?

1.  Use `criterion` for benchmarking
2. Add `rustc-hex` and `faster-hex` for benchmarking
3. Add format and clippy check