### PR TITLE
Make Sized optional in FromHex trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@ impl fmt::Display for FromHexError {
 ///     }
 /// }
 /// ```
-pub trait FromHex: Sized {
+pub trait FromHex: Sized? {
     type Error;
 
     /// Creates an instance of type `Self` from the given hex string, or fails


### PR DESCRIPTION
Better supports fixed types such as `[u8; 32]` by allowing the compiler to determine the data type's size.