### PR TITLE
Add serde feature

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,6 +113,7 @@ test:rust-stable:
     - compile:rust-stable
   script:
     - cargo test
+    - cargo test --features serde
     - cargo test --no-default-features
   variables:
     RUST_KEY: rust-stable
@@ -124,6 +125,7 @@ test:rust-stable-musl:
     - compile:rust-stable-musl
   script:
     - cargo test
+    - cargo test --features serde
     - cargo test --no-default-features
   variables:
     RUST_KEY: rust-stable-musl
@@ -135,6 +137,7 @@ test:rust-beta:
     - compile:rust-beta
   script:
     - cargo test
+    - cargo test --features serde
     - cargo test --no-default-features
   variables:
     RUST_KEY: rust-beta
@@ -146,6 +149,7 @@ test:rust-beta-musl:
     - compile:rust-beta-musl
   script:
     - cargo test
+    - cargo test --features serde
     - cargo test --no-default-features
   variables:
     RUST_KEY: rust-beta-musl
@@ -157,6 +161,7 @@ test:rust-nightly:
     - compile:rust-nightly
   script:
     - cargo test
+    - cargo test --features serde
     - cargo test --no-default-features
   variables:
     RUST_KEY: rust-nightly
@@ -169,6 +174,7 @@ test:rust-nightly-musl:
     - compile:rust-nightly-musl
   script:
     - cargo test
+    - cargo test --features serde
     - cargo test --no-default-features
   variables:
     RUST_KEY: rust-nightly-musl

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
   - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then cargo fmt -- --check; fi
   - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then cargo clippy -- -D clippy::all; fi
   - cargo test
+  - cargo test --features serde
   - cargo test --no-default-features
   # Validate benches still work.
   - cargo bench --all -- --test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,18 @@ std = []
 name = "hex"
 harness = false
 
+[dependencies]
+serde = { version = "1.0", optional = true }
+
 [dev-dependencies]
 criterion = "0.3"
 rustc-hex = "2.0"
 faster-hex = "0.4"
 version-sync = "0.8"
 pretty_assertions = "0.6"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 
 #![doc(html_root_url = "https://docs.rs/hex/0.4.0")]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::unreadable_literal)]
 #![warn(clippy::use_self)]
 
@@ -35,6 +36,12 @@ use core::iter;
 
 mod error;
 pub use error::FromHexError;
+
+#[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+pub mod serde;
+#[cfg(feature = "serde")]
+pub use crate::serde::{deserialize, serialize, serialize_upper};
 
 /// Encoding values as hex string.
 ///

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,88 @@
+//! Hex encoding with `serde`.
+//!
+//! # Example
+//!
+//! ```
+//! use serde::{Serialize, Deserialize};
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct Foo {
+//!     #[serde(with = "hex")]
+//!     bar: Vec<u8>,
+//! }
+//! ```
+//!
+use serde::de::{Error, Visitor};
+use serde::{Deserializer, Serializer};
+
+use std::fmt;
+use std::marker::PhantomData;
+
+use crate::{FromHex, ToHex};
+
+/// Serializes `data` as hex string using uppercase characters.
+///
+/// Apart from the characters' casing, this works exactly like `serialize()`.
+pub fn serialize_upper<S, T>(data: T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: ToHex,
+{
+    let s = data.encode_hex_upper::<String>();
+    serializer.serialize_str(&s)
+}
+
+/// Serializes `data` as hex string using lowercase characters.
+///
+/// Lowercase characters are used (e.g. `f9b4ca`). The resulting string's length
+/// is always even, each byte in data is always encoded using two hex digits.
+/// Thus, the resulting string contains exactly twice as many bytes as the input data.
+pub fn serialize<S, T>(data: T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: ToHex,
+{
+    let s = data.encode_hex::<String>();
+    serializer.serialize_str(&s)
+}
+
+/// Deserializes a hex string into raw bytes.
+///
+/// Both, upper and lower case characters are valid in the input string and can
+/// even be mixed (e.g. `f9b4ca`, `F9B4CA` and `f9B4Ca` are all valid strings).
+pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromHex,
+    <T as FromHex>::Error: fmt::Display,
+{
+    struct HexStrVisitor<T>(PhantomData<T>);
+
+    impl<'de, T> Visitor<'de> for HexStrVisitor<T>
+    where
+        T: FromHex,
+        <T as FromHex>::Error: fmt::Display,
+    {
+        type Value = T;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "a hex encoded string")
+        }
+
+        fn visit_str<E>(self, data: &str) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            FromHex::from_hex(data).map_err(|e| Error::custom(e))
+        }
+
+        fn visit_borrowed_str<E>(self, data: &'de str) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            FromHex::from_hex(data).map_err(|e| Error::custom(e))
+        }
+    }
+
+    deserializer.deserialize_str(HexStrVisitor(PhantomData))
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,58 @@
+#![cfg(feature = "serde")]
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct Foo {
+    #[serde(with = "hex")]
+    bar: Vec<u8>,
+}
+
+#[test]
+fn serialize() {
+    let foo = Foo {
+        bar: vec![1, 10, 100],
+    };
+
+    let ser = serde_json::to_string(&foo).expect("serialization failed");
+    assert_eq!(ser, r#"{"bar":"010a64"}"#);
+}
+
+#[test]
+fn dserialize() {
+    let foo = Foo {
+        bar: vec![1, 10, 100],
+    };
+
+    let de: Foo = serde_json::from_str(r#"{"bar":"010a64"}"#).expect("deserialization failed");
+    assert_eq!(de, foo);
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct Bar {
+    #[serde(
+        serialize_with = "hex::serialize_upper",
+        deserialize_with = "hex::deserialize"
+    )]
+    foo: Vec<u8>,
+}
+
+#[test]
+fn serialize_upper() {
+    let bar = Bar {
+        foo: vec![1, 10, 100],
+    };
+
+    let ser = serde_json::to_string(&bar).expect("serialization failed");
+    assert_eq!(ser, r#"{"foo":"010A64"}"#);
+}
+
+#[test]
+fn dserialize_upper() {
+    let bar = Bar {
+        foo: vec![1, 10, 100],
+    };
+
+    let de: Bar = serde_json::from_str(r#"{"foo":"010A64"}"#).expect("deserialization failed");
+    assert_eq!(de, bar);
+}


### PR DESCRIPTION
Example

```rust
use serde::{Serialize, Deserialize};

#[derive(Serialize, Deserialize)]
struct Foo {
    #[serde(with = "hex")]
    bar: Vec<u8>,
}
```