### PR TITLE
Use const-generics to implement FromHex trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,44 +201,15 @@ impl FromHex for Vec<u8> {
     }
 }
 
-// Helper macro to implement the trait for a few fixed sized arrays. Once Rust
-// has type level integers, this should be removed.
-macro_rules! from_hex_array_impl {
-    ($($len:expr)+) => {$(
-        impl FromHex for [u8; $len] {
-            type Error = FromHexError;
+impl<const N: usize> FromHex for [u8; N] {
+    type Error = FromHexError;
 
-            fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
-                let mut out = [0_u8; $len];
-                decode_to_slice(hex, &mut out as &mut [u8])?;
-                Ok(out)
-            }
-        }
-    )+}
-}
+    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
+        let mut out = [0_u8; N];
+        decode_to_slice(hex, &mut out as &mut [u8])?;
 
-from_hex_array_impl! {
-    1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
-    17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32
-    33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48
-    49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64
-    65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80
-    81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96
-    97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112
-    113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128
-    160 192 200 224 256 384 512 768 1024 2048 4096 8192 16384 32768
-}
-
-#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
-from_hex_array_impl! {
-    65536 131072 262144 524288 1048576 2097152 4194304 8388608
-    16777216 33554432 67108864 134217728 268435456 536870912
-    1073741824 2147483648
-}
-
-#[cfg(target_pointer_width = "64")]
-from_hex_array_impl! {
-    4294967296
+        Ok(out)
+    }
 }
 
 /// Encodes `data` as hex string using lowercase characters.


### PR DESCRIPTION
In rust version 1.51 a small subset of const-generics has been
stabilized, which removes the need for the previously used macro.

Because of the widespread use of this crate and previous issues with minor versions breaking the msrv of this crate, I would suggest making this PR part of the 0.5.0 release.