### PR TITLE
feat(FromHexError): derive Eq for enum FromHexError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 /// The error type for decoding a hex string into `Vec<u8>` or `[u8; N]`.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FromHexError {
     /// An invalid character was found. Valid ones are: `0...9`, `a...f`
     /// or `A...F`.


### PR DESCRIPTION
The type `FromHexError` can be completely equated as every member of the enum can be completely equated.
Fixes #76 