### PR TITLE
add array lookup to decoder for notieable perf boost with minimal code change

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,10 +178,12 @@ const fn val(c: u8, idx: usize) -> Result<u8, FromHexError> {
         let mut i = 0;
 
         while i < arr.len() {
-            arr[i] = match i as u8 {
-                c @ b'A'..=b'F' => c - b'A' + 10,
-                c @ b'a'..=b'f' => c - b'a' + 10,
-                c @ b'0'..=b'9' => c - b'0',
+            // will not overflow as i < 256 or loop breaks
+            let c = i as u8;
+            arr[i] = match c {
+                b'A'..=b'F' => c - b'A' + 10,
+                b'a'..=b'f' => c - b'a' + 10,
+                b'0'..=b'9' => c - b'0',
                 _ => 255,
             };
             i += 1;
@@ -192,7 +194,7 @@ const fn val(c: u8, idx: usize) -> Result<u8, FromHexError> {
 
     let val = LOOKUP[c as usize];
 
-    if val == 0xff {
+    if val == 255 {
         Err(FromHexError::InvalidHexCharacter {
             c: c as char,
             index: idx,


### PR DESCRIPTION
After evaluating what I believe this crates goals are (being simple) I have come up with (along with the help of browsing other hex crates performance boosting methods) a minimal code change that doesn't sacrifice a lot of readability, or dip into unsafe, while still giving a noticeable speedup to the decoder.

Its possible that even simpler changes could speed up the crate, but this is the least intrusive method I have found that still produces a real performance gain (over the past few days of looking into this).

This code passes all tests, fmt, and clippy (stable rust 1.72).

Relevant benchmarks (using `benches/hex.rs`):
```
Performed on a Ryzen 2600

Before change
hex_decode              time:   [139.11 µs 139.97 µs 140.95 µs]                       

After change
hex_decode              time:   [107.11 µs 108.24 µs 109.44 µs]                       
```

This crate is a candidate to include `#![forbid(unsafe_code)]`, and I recommend doing so, but that is outside of the scope of this PR.