### PR TITLE
Fix documentation feature labels on re-exports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ maintenance = { status = "actively-developed" }
 default = ["std"]
 alloc = []
 std = ["alloc"]
+serde = ["dep:serde"]
 
 [[bench]]
 name = "hex"

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 //! Hex encoding with `serde`.
-#[cfg_attr(
+#![cfg_attr(
     all(feature = "alloc", feature = "serde"),
     doc = r##"
 # Example
@@ -36,6 +36,7 @@ use crate::ToHex;
 ///
 /// Apart from the characters' casing, this works exactly like `serialize()`.
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn serialize_upper<S, T>(data: T, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -52,6 +53,7 @@ where
 /// Thus, the resulting string contains exactly twice as many bytes as the input
 /// data.
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn serialize<S, T>(data: T, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,


### PR DESCRIPTION
(#91 again, commit somehow got lost?)

Clarifies which features are required for which functions in this documentation. This change also uses `dep:serde` for the `serde` feature which is more explicit and was added in Rust 1.60 so it doesn't change the MSRV.

### hex

<img width="500" alt="image" src="https://github.com/user-attachments/assets/de81a98f-09a7-416d-9238-93560480bdf1" />

### hex::serde

<img width="500" alt="image" src="https://github.com/user-attachments/assets/aee79815-6a10-4d6d-9df8-0e07772d6065" />

Fixes #90
